### PR TITLE
Update to 3.0.0 + remove the million aliases

### DIFF
--- a/SSS/plugin.yml
+++ b/SSS/plugin.yml
@@ -1,5 +1,5 @@
 name: SignServerStats
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11]
+api: 3.0.0
 version: 1.1.0
 load: POSTWORLD
 main: robske_110\SSS\SignServerStats
@@ -8,8 +8,11 @@ author: robske_110
 permissions:
  SSS:
   description: "Allows to use all SSS features"
+  default: false
   children:
    SSS.signs:
      description: "Allows to create [SSS] signs and destroy them"
+     default: op
    SSS.servertransfer:
      description: "Allows to click on a SSSign and get transferred to that server."
+     default: true

--- a/SSS/src/robske_110/SSS/SSSAsyncTaskCaller.php
+++ b/SSS/src/robske_110/SSS/SSSAsyncTaskCaller.php
@@ -8,14 +8,14 @@
 */
 namespace robske_110\SSS;
 
-use pocketmine\scheduler\PluginTask;
+use pocketmine\scheduler\Task;
 
-class SSSAsyncTaskCaller extends PluginTask{
+class SSSAsyncTaskCaller extends Task {
+
 	/** @var SignServerStats */
 	private $sss;
 	
 	public function __construct(SignServerStats $main){
-		parent::__construct($main);
 		$this->sss = $main;
 	}
 	

--- a/SSS/src/robske_110/SSS/SSSListener.php
+++ b/SSS/src/robske_110/SSS/SSSListener.php
@@ -12,12 +12,12 @@ use pocketmine\event\Listener;
 use pocketmine\event\block\BlockBreakEvent;
 use pocketmine\event\block\SignChangeEvent;
 use pocketmine\event\player\PlayerInteractEvent;
+use pocketmine\scheduler\Task;
 use pocketmine\tile\Sign;
 use pocketmine\Server;
 use pocketmine\Player;
 use pocketmine\utils\TextFormat as TF;
 use pocketmine\block\BlockIds;
-use pocketmine\scheduler\PluginTask;
 
 class SSSListener implements Listener{
 	private $main;
@@ -94,8 +94,8 @@ class SSSListener implements Listener{
 						if(!$this->main->getServerOnline()[$address[0]."@".$address[1]]){
 							return;
 						}
-						$this->main->getServer()->getScheduler()->scheduleDelayedTask(
-							new class($this->main, $player, $address[0], $address[1], $id) extends PluginTask{
+						$this->main->getScheduler()->scheduleDelayedTask(
+							new class($this->main, $player, $address[0], $address[1], $id) extends Task {
 								/** @var Player */
 								private $player;
 								/** @var string */
@@ -106,7 +106,6 @@ class SSSListener implements Listener{
 								private $id;
 									
 								public function __construct(SignServerStats $plugin, Player $player, string $ip, int $port, int $id){
-									parent::__construct($plugin);
 									$this->player = $player;
 									$this->ip = $ip;
 									$this->port = $port;

--- a/SSS/src/robske_110/SSS/SignServerStats.php
+++ b/SSS/src/robske_110/SSS/SignServerStats.php
@@ -102,7 +102,7 @@ class SignServerStats extends PluginBase{
 		$this->doRefreshSigns = $this->db->getAll();
 		$this->recalcdRSvar();
 		$this->timeout = $this->signServerStatsCfg->get('server-query-timeout-sec');
-		$this->server->getScheduler()->scheduleRepeatingTask(
+		$this->getScheduler()->scheduleRepeatingTask(
 			new SSSAsyncTaskCaller($this), $this->signServerStatsCfg->get("async-task-call-ticks")
 		);
 	}
@@ -303,7 +303,7 @@ class SignServerStats extends PluginBase{
 	 */
 	public function startAsyncTask($currTick){
 		$this->asyncTaskIsRunning = true;
-		$this->server->getScheduler()->scheduleAsyncTask(new SSSAsyncTask($this->doCheckServers, $this->debug, $this->timeout, $currTick));
+		$this->server->getAsyncPool()->submitTask(new SSSAsyncTask($this->doCheckServers, $this->debug, $this->timeout, $currTick));
 	}
 	
 	/**

--- a/examples/DumpInfo.php
+++ b/examples/DumpInfo.php
@@ -4,7 +4,7 @@
  * @name DumpServerInfo
  * @main robske_110\DPS\DumpServerInfo
  * @version 1.0.0
- * @api 3.0.0-ALPHA11
+ * @api 3.0.0
  * @description Dumps query info of a Server using SignServerStats
  * @author robske_110
  * @license MIT
@@ -19,7 +19,7 @@ namespace robske_110\DPS{
 	use pocketmine\command\Command;
 	use pocketmine\command\CommandSender;
 	use pocketmine\utils\TextFormat as TF;
-	use pocketmine\scheduler\PluginTask;
+	use pocketmine\scheduler\Task;
 
 	class DumpServerInfo extends PluginBase{
 		
@@ -53,7 +53,7 @@ namespace robske_110\DPS{
 				return;
 			}
 			$this->displayTask = new DisplayTask($this);
-			$this->getServer()->getScheduler()->scheduleRepeatingTask($this->displayTask, 10);
+			$this->getScheduler()->scheduleRepeatingTask($this->displayTask, 10);
 		}
 		
 		public function getSSS(): ?SignServerStats{
@@ -91,12 +91,11 @@ namespace robske_110\DPS{
 		}
 	}
 	
-	class DisplayTask extends PluginTask{
+	class DisplayTask extends Task {
 		private $plugin;
 		private $checkServers = [];
 	
 	    public function __construct(DumpServerInfo $plugin){
-	        parent::__construct($plugin);
 	        $this->plugin = $plugin;
 	    }
 	

--- a/examples/LinkPlayerCount/plugin.yml
+++ b/examples/LinkPlayerCount/plugin.yml
@@ -1,5 +1,5 @@
 name: LinkPlayerCount
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11]
+api: 3.0.0
 version: 1.0.0
 depend: SignServerStats
 load: POSTWORLD
@@ -11,15 +11,17 @@ commands:
   description: Adds a sepecified server
   usage: "/linkplayercount add <hostname> [port]"
   permission: LinkPlayerCount.manageList
-  aliases: [addLPC, addlpc, lpcadd, LPCadd, lpc add, LPC add]
+  aliases: [lpc add]
  linkplayercount rem:
   description: Removes a sepecified server
   usage: "/linkplayercount rem <hostname> [port]"
   permission: LinkPlayerCount.manageList
-  aliases: [remLPC, remlpc, lpcrem, LPCrem, lpc rem, LPC rem, linkplayercount remove]
+  aliases: [lpc rem]
 permissions:
  LinkPlayerCount:
   description: "Allows to use all LinkPlayerCount features"
+  default: false
   children:
    LinkPlayerCount.manageList:
     description: "Users with this permission will be able to add/remove servers."
+    default: op

--- a/examples/StatusList/plugin.yml
+++ b/examples/StatusList/plugin.yml
@@ -1,5 +1,5 @@
 name: StatusList
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11]
+api: 3.0.0
 version: 1.1.0
 depend: SignServerStats
 load: POSTWORLD
@@ -11,23 +11,26 @@ commands:
   description: Adds a sepecified server to the statuslist
   usage: "/statuslist add <hostname> [port]"
   permission: StatusList.manageList
-  aliases: [addSL, addsl, SLadd, sladd, addSserver, addStatusS, sl add, SL add]
+  aliases: [sl add]
  statuslist rem:
   description: Removes a sepecified server from the statuslist
   usage: "/statuslist rem <hostname> [port]"
   permission: StatusList.manageList
-  aliases: [remSL, remsl, SLrem, slrem, remSserver, remStatusS, sl rem, SL rem, statuslist remove]
+  aliases: [sl rem]
  statuslist show:
    description: Shows all servers on the statuslist
    usage: "/statuslist show <hostname> [port]"
    permission: StatusList.seeList
-   aliases: [showSL, showsl, SLshow, slshow, listStatusList, showStatusList, sl show, SL show, statuslist list]
+   aliases: [sl show]
 
 permissions:
  StatusList:
   description: "Allows to use all StatusList features"
+  default: false
   children:
    StatusList.seeList:
     description: "Users with this permission will be able to see the statuslist."
+    default: op
    StatusList.manageList:
     description: "Users with this permission will be able to add/remove servers from the statuslist."
+    default: op

--- a/examples/WarnOffline/plugin.yml
+++ b/examples/WarnOffline/plugin.yml
@@ -1,5 +1,5 @@
 name: WarnOffline
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11]
+api: 3.0.0
 version: 1.1.0
 depend: StatusList
 load: POSTWORLD
@@ -9,6 +9,8 @@ author: robske_110
 permissions:
  WarnOffline:
   description: "Allows to use all WarnOffline features"
+  default: false
   children:
    WarnOffline.notify:
     description: "Users with this permission will be notified if a server from the statuslist goes down."
+    default: op


### PR DESCRIPTION
* Updated to 3.0.0

* removed most aliases, but kept shortened version of plugin name. (ex: `/lpc add`)

* added `default:` to plugin.yml because it seemed like, at least on PurePerms, even if I gave them the permission node, they were not able to use the command still. Only when I added `default:`, they were able to use the command. 

i think i didn't do anything wrong. 